### PR TITLE
Add lmtp_replies

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -18,6 +18,8 @@ status_replies:
   [ - <status_reply>, ... ]
 smtp_replies:
   [ - <smtp_reply>, ... ]
+lmtp_replies:
+  [ - <lmtp_reply>, ... ]
 noqueue_reject_replies:
   [ - <noqueue_reject_reply>, ... ]
 ```
@@ -71,6 +73,33 @@ In this case:
 
 * `123` is a status code
 * `1.2.3` is an enhanced status code (might be empty if absent)
+* `Reasons` is the text of the reply
+
+```yml
+# The regular expression matching the reply code, enhanced code or text.
+regexp: <regex>
+
+# Match type. Accepted values: code, enhanced_code, text.
+[ match: <string> | default = "text" ]
+
+# The replacement text (may include placeholders supported by Go, see https://pkg.go.dev/regexp#Regexp.Expand).
+text: <string>
+```
+
+### `<lmtp_reply>`
+
+The LMTP replies are like status replies but without Postfix statuses.
+
+Example log entry:
+
+```
+Jan 1 00:00:00 hostname postfix/lmtp[12345]: 123456789AB: to=<user@example.com>, relay=example.com[/var/run/dovecot/lmtp], delay=1.23, delays=1.23/1.23/1.23/1.23, dsn=1.2.3, status=deferred (host example.com[/var/run/dovecot/lmtp] said: 452 4.2.2 Reasons (in reply to end of DATA command))
+```
+
+In this case:
+
+* `452` is a status code
+* `4.2.2` is an enhanced status code (might be empty if absent)
 * `Reasons` is the text of the reply
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ docker run -d -p 9907:9907 -v postfix_logs:/var/log/postfix sergeymakinen/postfi
 | postfix_delay_seconds | Delay in seconds for a server to process a message. | subprogram, status
 | postfix_status_replies_total | Total number of times server message status change event replies were collected. Requires [configuration](CONFIGURATION.md) to be present. | subprogram, status, code, enhanced_code, text
 | postfix_smtp_replies_total | Total number of times SMTP server replies were collected. Requires [configuration](CONFIGURATION.md) to be present. | code, enhanced_code, text
+| postfix_lmtp_replies_total | Total number of times LMTP server replies were collected. Requires [configuration](CONFIGURATION.md) to be present. | code, enhanced_code, text
 | postfix_milter_actions_total | Total number of times milter events were collected. | subprogram, action
 | postfix_login_failures_total | Total number of times login failure events were collected. | subprogram, method
 | postfix_qmgr_statuses_total | Total number of times Postfix queue manager message status change events were collected. | status
@@ -80,9 +81,9 @@ using the `--web.config.file` parameter. The format of the file is described
 
 ### Testing postfix_exporter on your system
 
-The metrics are computed from the logs, with a time range that goes from the time postfix_exporter is run up to the time where postfix_exporter metrics path is called.  
-In order to test postfix_exporter regex rulesets on earlier logs, postfix_exporter can be run with with `--test` flag.  
-Please bear in mind that when using journald as log source, you'll have to specify a minimum journald parsing range, like the last 24h.  
+The metrics are computed from the logs, with a time range that goes from the time postfix_exporter is run up to the time where postfix_exporter metrics path is called.
+In order to test postfix_exporter regex rulesets on earlier logs, postfix_exporter can be run with with `--test` flag.
+Please bear in mind that when using journald as log source, you'll have to specify a minimum journald parsing range, like the last 24h.
 Example:
 ```
 postfix_exporter --config.check --collector journald --journald.unit postfix.service --journald.since 24h --test

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 type Config struct {
 	StatusReplies        []StatusReplyMatchConfig `yaml:"status_replies,omitempty"`
 	SmtpReplies          []ReplyMatchConfig       `yaml:"smtp_replies,omitempty"`
+	LmtpReplies          []ReplyMatchConfig       `yaml:"lmtp_replies,omitempty"`
 	NoqueueRejectReplies []ReplyMatchConfig       `yaml:"noqueue_reject_replies,omitempty"`
 }
 

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -21,7 +21,7 @@ const namespace = "postfix"
 var ErrUnsupportedCollector = errors.New("unsupported collector")
 
 var (
-	ipAddrPart = `[a-f0-9:.]+`
+	ipAddrPart = `[a-z0-9:./]+`
 
 	psIPAddrPart       = `\[` + ipAddrPart + `]`
 	rePsConnect        = regexp.MustCompile(`^CONNECT from ` + psIPAddrPart)
@@ -85,6 +85,7 @@ type Exporter struct {
 	delays               *prometheus.SummaryVec
 	statusReplies        *prometheus.CounterVec
 	smtpReplies          *prometheus.CounterVec
+	lmtpReplies          *prometheus.CounterVec
 	milter               *prometheus.CounterVec
 	loginFailed          *prometheus.CounterVec
 	qmgrStatuses         *prometheus.CounterVec
@@ -115,6 +116,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	e.delays.Describe(ch)
 	e.statusReplies.Describe(ch)
 	e.smtpReplies.Describe(ch)
+	e.lmtpReplies.Describe(ch)
 	e.milter.Describe(ch)
 	e.loginFailed.Describe(ch)
 	e.qmgrStatuses.Describe(ch)
@@ -137,6 +139,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.delays.Collect(ch)
 	e.statusReplies.Collect(ch)
 	e.smtpReplies.Collect(ch)
+	e.lmtpReplies.Collect(ch)
 	e.milter.Collect(ch)
 	e.loginFailed.Collect(ch)
 	e.qmgrStatuses.Collect(ch)
@@ -314,7 +317,21 @@ func (e *Exporter) process(r record, err error) {
 			e.statuses.WithLabelValues(r.Subprogram, matches[2]).Inc()
 			f, _ := strconv.ParseFloat(matches[1], 64)
 			e.delays.WithLabelValues(r.Subprogram, matches[2]).Observe(f)
-			parseStatusReply(matches)
+			if m := reHostSaid.FindStringSubmatch(matches[3]); m != nil {
+				reply, err := parseHostReply(m[1])
+				if err == nil {
+					if cfg, m := findSubmatch(e.config.LmtpReplies, func(cfg config.ReplyMatchConfig) []int {
+						return cfg.Regexp.FindStringSubmatchIndex(reply.Text)
+					}); m != nil {
+						text := string(cfg.Regexp.ExpandString(nil, cfg.Text, reply.Text, m))
+						e.lmtpReplies.WithLabelValues(reply.Code, reply.EnhancedCode, text).Inc()
+					}
+				} else {
+					e.logger.Warn("Error parsing host reply", "record", r, "err", err)
+				}
+			} else {
+				parseStatusReply(matches)
+			}
 		} else {
 			found = false
 		}
@@ -411,6 +428,11 @@ func New(collector Collector, instance string, cfg *config.Config, logger *slog.
 			Namespace: namespace,
 			Name:      "smtp_replies_total",
 			Help:      "Total number of times SMTP server replies were collected.",
+		}, []string{"code", "enhanced_code", "text"}),
+		lmtpReplies: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "lmtp_replies_total",
+			Help:      "Total number of times LMTP server replies were collected.",
 		}, []string{"code", "enhanced_code", "text"}),
 		milter: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,

--- a/exporter/testdata/mail.log
+++ b/exporter/testdata/mail.log
@@ -47,6 +47,7 @@ Jan 1 00:00:00 hostname postfix/smtpd[12345]: Unsupported
 # lmtp
 Jan 1 00:00:00 hostname postfix/lmtp[12345]: 123456789AB: to=<user@example.com>, relay=example.com[path], delay=0.12, delays=0.12/0.12/0.12/0.12, dsn=1.2.3, status=sent (250 2.0.0 Ok: queued as aaaaaaaaaaaaa)
 2023-02-01T01:02:04.123456+00:00 hostname postfix/lmtp[12345]: 123456789AB: to=<user@example.com>, relay=example.com[123.45.67.89]:25, delay=1.23, delays=1.23/1.23/1.23/1.23, dsn=1.2.3, status=bounced (123 #1.2.3 Reasons)
+2023-02-01T01:02:04.123456+00:00 hostname postfix/lmtp[12345]: 123456789AB: to=<user@example.com>, relay=example.com[/var/run/dovecot/lmtp], delay=1.23, delays=1.23/1.23/1.23/1.23, dsn=1.2.3, status=deferred (host example.com[/var/run/dovecot/lmtp] said: 452 4.2.2 <user@example.com> Quota exceeded (mailbox for user is full) (in reply to end of DATA command))
 Jan 1 00:00:00 hostname postfix/lmtp[12345]: Unsupported
 # smtp
 Jan 1 00:00:00 hostname postfix/smtp[12345]: 123456789AB: to=<user@example.com>, relay=example.com[123.45.67.89]:123, delay=0.12, delays=0.12/0.12/0.12/0.12, dsn=1.2.3, status=sent (250 2.0.0 Ok: queued as aaaaaaaaaaaaa)

--- a/exporter/testdata/metrics-with-config.txt
+++ b/exporter/testdata/metrics-with-config.txt
@@ -13,6 +13,11 @@ postfix_delay_seconds{status="bounced",subprogram="smtp",quantile="0.9"} 1.23
 postfix_delay_seconds{status="bounced",subprogram="smtp",quantile="0.99"} 1.23
 postfix_delay_seconds_sum{status="bounced",subprogram="smtp"} 1.23
 postfix_delay_seconds_count{status="bounced",subprogram="smtp"} 1
+postfix_delay_seconds{status="deferred",subprogram="lmtp",quantile="0.5"} 1.23
+postfix_delay_seconds{status="deferred",subprogram="lmtp",quantile="0.9"} 1.23
+postfix_delay_seconds{status="deferred",subprogram="lmtp",quantile="0.99"} 1.23
+postfix_delay_seconds_sum{status="deferred",subprogram="lmtp"} 1.23
+postfix_delay_seconds_count{status="deferred",subprogram="lmtp"} 1
 postfix_delay_seconds{status="deferred",subprogram="smtp",quantile="0.5"} 2
 postfix_delay_seconds{status="deferred",subprogram="smtp",quantile="0.9"} 2
 postfix_delay_seconds{status="deferred",subprogram="smtp",quantile="0.99"} 2
@@ -38,7 +43,7 @@ postfix_login_failures_total{method="LOGIN",subprogram="smtpd"} 1
 # TYPE postfix_logs_total counter
 postfix_logs_total{severity="error",subprogram="postscreen"} 1
 postfix_logs_total{severity="info",subprogram="cleanup"} 2
-postfix_logs_total{severity="info",subprogram="lmtp"} 3
+postfix_logs_total{severity="info",subprogram="lmtp"} 4
 postfix_logs_total{severity="info",subprogram="postscreen"} 22
 postfix_logs_total{severity="info",subprogram="qmgr"} 2
 postfix_logs_total{severity="info",subprogram="smtp"} 9
@@ -102,6 +107,7 @@ postfix_status_replies_total{code="250",enhanced_code="",status="sent",subprogra
 postfix_statuses_total{status="bounced",subprogram="lmtp"} 1
 postfix_statuses_total{status="bounced",subprogram="smtp"} 1
 postfix_statuses_total{status="deferred",subprogram="smtp"} 2
+postfix_statuses_total{status="deferred",subprogram="lmtp"} 1
 postfix_statuses_total{status="sent",subprogram="lmtp"} 1
 postfix_statuses_total{status="sent",subprogram="smtp"} 2
 # HELP postfix_unsupported_total Total number of unsupported log records.

--- a/exporter/testdata/metrics-without-config.txt
+++ b/exporter/testdata/metrics-without-config.txt
@@ -13,6 +13,11 @@ postfix_delay_seconds{status="bounced",subprogram="smtp",quantile="0.9"} 1.23
 postfix_delay_seconds{status="bounced",subprogram="smtp",quantile="0.99"} 1.23
 postfix_delay_seconds_sum{status="bounced",subprogram="smtp"} 1.23
 postfix_delay_seconds_count{status="bounced",subprogram="smtp"} 1
+postfix_delay_seconds{status="deferred",subprogram="lmtp",quantile="0.5"} 1.23
+postfix_delay_seconds{status="deferred",subprogram="lmtp",quantile="0.9"} 1.23
+postfix_delay_seconds{status="deferred",subprogram="lmtp",quantile="0.99"} 1.23
+postfix_delay_seconds_sum{status="deferred",subprogram="lmtp"} 1.23
+postfix_delay_seconds_count{status="deferred",subprogram="lmtp"} 1
 postfix_delay_seconds{status="deferred",subprogram="smtp",quantile="0.5"} 2
 postfix_delay_seconds{status="deferred",subprogram="smtp",quantile="0.9"} 2
 postfix_delay_seconds{status="deferred",subprogram="smtp",quantile="0.99"} 2
@@ -38,7 +43,7 @@ postfix_login_failures_total{method="LOGIN",subprogram="smtpd"} 1
 # TYPE postfix_logs_total counter
 postfix_logs_total{severity="error",subprogram="postscreen"} 1
 postfix_logs_total{severity="info",subprogram="cleanup"} 2
-postfix_logs_total{severity="info",subprogram="lmtp"} 3
+postfix_logs_total{severity="info",subprogram="lmtp"} 4
 postfix_logs_total{severity="info",subprogram="postscreen"} 22
 postfix_logs_total{severity="info",subprogram="qmgr"} 2
 postfix_logs_total{severity="info",subprogram="smtp"} 9
@@ -87,6 +92,7 @@ postfix_qmgr_statuses_total{status="expired"} 1
 postfix_statuses_total{status="bounced",subprogram="lmtp"} 1
 postfix_statuses_total{status="bounced",subprogram="smtp"} 1
 postfix_statuses_total{status="deferred",subprogram="smtp"} 2
+postfix_statuses_total{status="deferred",subprogram="lmtp"} 1
 postfix_statuses_total{status="sent",subprogram="lmtp"} 1
 postfix_statuses_total{status="sent",subprogram="smtp"} 2
 # HELP postfix_unsupported_total Total number of unsupported log records.

--- a/exporter/testdata/postfix.yml
+++ b/exporter/testdata/postfix.yml
@@ -21,6 +21,9 @@ status_replies:
 smtp_replies:
   - regexp: (?i)gr(a|e)ylist
     text: graylist
+lmtp_replies:
+  - regexp: (?i)Quota exceeded
+    text: quota_exceeded
 noqueue_reject_replies:
   - regexp: '(Client host rejected: cannot find your hostname|Recipient address rejected: Rejected by SPF)'
     text: $1


### PR DESCRIPTION
Hello,

In my setup, I found that postfix_exporter unable to parse logs from lmtp subsystem. To fix that:

1. I changed `ipAddrPart` regexp, so it matches unix socket  (example: `/var/run/dovecot/lmtp`)
2. added new metric `postfix_lmtp_replies_total`
3. added config option `lmtpReplies` (based on smtpReplies)

With these changes, logs from lmtp subsystem are parsed correctly.